### PR TITLE
Fix a typo of storage.config.en.rst

### DIFF
--- a/doc/reference/configuration/storage.config.en.rst
+++ b/doc/reference/configuration/storage.config.en.rst
@@ -63,7 +63,7 @@ supported. They include
 
    - ``K`` Kilobytes (1024 bytes)
    - ``M`` Megabytes (1024^2 or 1,048,576 bytes)
-   - ``G`` Gigabytes (1024^3 or 1,073,741,824 bytes
+   - ``G`` Gigabytes (1024^3 or 1,073,741,824 bytes)
    - ``T`` Terabytes (1024^4 or 1,099,511,627,776 bytes)
 
 


### PR DESCRIPTION
storage.config.en.rst 原文の typo を修正します。
