### PR TITLE
DOC: Translate arch/cache/cache-data-structures

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/arch/cache/cache-data-structures.en.po
+++ b/doc/locale/ja/LC_MESSAGES/arch/cache/cache-data-structures.en.po
@@ -13,7 +13,7 @@ msgstr ""
 
 #: ../../arch/cache/cache-data-structures.en.rst:19
 msgid "Cache Data Structures"
-msgstr ""
+msgstr "キャッシュデータ構造"
 
 #: ../../arch/cache/cache-data-structures.en.rst:25
 msgid ""
@@ -21,18 +21,20 @@ msgid ""
 ":cpp:class:`Dir` plus additional information from the first "
 ":cpp:class:`Doc`."
 msgstr ""
+"オープンされたディレクトリエントリ。 :cpp:class:`Dir` と、それに加えて "
+"先頭の :cpp:class:`Doc` の全情報を含みます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:29
 msgid "A virtual connection class which accepts input for writing to cache."
-msgstr ""
+msgstr "キャッシュへ書込む入力を受け付ける仮想接続クラス。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:33
 msgid "Do the initial read for a cached object."
-msgstr ""
+msgstr "キャッシュされたオブジェクトの初回の読込みを実行します。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:37
 msgid "Do the initial read for an alternate of an object."
-msgstr ""
+msgstr "オブジェクトの代替の初回の読込みを実行します。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:41
 msgid ""
@@ -43,10 +45,16 @@ msgid ""
 "when the data is modified or for sources (which acquire data from outside "
 "|TS|) and sinks (which move data to outside |TS|)."
 msgstr ""
+"データ転送ドライバ。これは *プロデューサ* のセットを含みます。各プロデューサは"
+"一つ以上の *コンシューマ* に接続されます。トンネルは、プロデューサからコンシュ"
+"ーマへデータを移動させる為に、イベントとバッファを扱います。データは、"
+"データが修正される時のみ、またはソース(|TS| の外からデータを取得するもの)と"
+"シンク(|TS| の外へデータを移動するもの)のためにコピーが実行されるため、可能な"
+"限り参照カウントバッファに維持されます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:45
 msgid "Holds the data from a line in :file:`cache.config`."
-msgstr ""
+msgstr ":file:`cache.config` のある行からデータを保持します。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:49
 msgid ""
@@ -54,11 +62,14 @@ msgid ""
 "objects and serves as the respository of information about alternates of an "
 "object. It is marshaled as part of the metadata for an object in the cache."
 msgstr ""
+"|P-CacheHttp.h|_ で定義されます。これは :cpp:class:`HTTPInfo` オブジェクトの"
+"配列であり、オブジェクトの代替に関する情報のリポジトリとして提供します。"
+"それはキャッシュ内のオブジェクトのメタデータ部分に配置されます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:53
 #: ../../arch/cache/cache-data-structures.en.rst:63
 msgid "Defined in |HTTP.h|_."
-msgstr ""
+msgstr "|HTTP.h|_ で定義されます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:55
 msgid ""
@@ -66,40 +77,45 @@ msgid ""
 "external API for accessing data in the wrapped class. It contains only a "
 "pointer (possibly ``NULL``) to an instance of the wrapped class."
 msgstr ""
+"このクラスは :cpp:class:`HTTPCacheAlt` のラッパーです。ラップされたクラス内の"
+"データへのアクセスのための外部 API を提供します。ラップされたクラスのインスタ"
+"ンスへのポインター(``NULL`` の可能性がある)のみ保持します。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:59
 msgid "A typedef for :cpp:class:`HTTPInfo`."
-msgstr ""
+msgstr ":cpp:class:`HTTPInfo` の typedef 。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:65
 msgid ""
 "This is the metadata for a single alternate for a cached object. In contains"
 " among other data"
 msgstr ""
+"キャッシュオブジェクトの単一の代替のメタデータです。下記の他データを"
+"含みます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:67
 msgid "The key for the earliest ``Doc`` of the alternate."
-msgstr ""
+msgstr "代替の earliest ``Doc`` のキー。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:68
 msgid "The request and response headers."
-msgstr ""
+msgstr "リクエストヘッダとレスポンスヘッダ。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:69
 msgid "The fragment offset table. [#]_"
-msgstr ""
+msgstr "フラグメントオフセットテーブル。 [#]_"
 
 #: ../../arch/cache/cache-data-structures.en.rst:70
 msgid "Timestamps for request and response from origin server."
-msgstr ""
+msgstr "オリジンサーバからのリクエストとレスポンスのタイムスタンプ。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:74
 msgid "Record for evacuation."
-msgstr ""
+msgstr "退避のためのレコード。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:78
 msgid "This represents a storage unit inside a cache volume."
-msgstr ""
+msgstr "キャッシュボリューム内においてストレージユニットを表します。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:82
 msgid ""
@@ -107,6 +123,8 @@ msgid ""
 "of entries divided by the number of entries in a segment. It will be rounded"
 " up to cover all entries."
 msgstr ""
+"ボリュームのセグメント数。セグメント内のエントリ数で分割されたエントリの"
+"おおよその合計数。全エントリをカバーするように丸め込まれます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:86
 msgid ""
@@ -115,16 +133,21 @@ msgid ""
 "this is around 16,384 (2^16 / 4). Buckets are used as the targets of the "
 "index hash."
 msgstr ""
+"ボリュームのバケット数。 ``DIR_DEPTH`` で分割されるセグメント内のおおよその"
+"エントリ数。現在は約 16,384 (2^16 / 4) で定義されます。バケットはインデックス"
+"ハッシュの対象として使用されます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:90
 msgid ""
 "Array of of :cpp:class:`EvacuationBlock` buckets. This is sized so there is "
 "one bucket for every evacuation span."
 msgstr ""
+":cpp:class:`EvacuationBlock` バケットの配列。これは、退避スパンごとに一つの"
+"バケットを持つようなサイズになります。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:94
 msgid "Length of stripe in bytes."
-msgstr ""
+msgstr "バイト単位のストライプ長。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:98
 msgid ""
@@ -132,36 +155,41 @@ msgid ""
 "range from *low* to *high*. Return 0 if no evacuation was started, non-zero "
 "otherwise."
 msgstr ""
+"*low* から *high* の範囲に任意の :cpp:class:`EvacuationBlock` がある場合、退避"
+"を開始します。退避が開始されなかった場合は 0 を、それ以外は非 0 を返します。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:102
 msgid "A cache volume as described in :file:`volume.config`."
-msgstr ""
+msgstr ":file:`volume.config` で記述されるキャッシュボリューム。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:106
 msgid "Defined in |P-CacheVol.h|_."
-msgstr ""
+msgstr "|P-CacheVol.h|_ で定義されます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:110
 msgid "Validity check value. Set to ``DOC_MAGIC`` for a valid document."
-msgstr ""
+msgstr "正当性チェック値。正当なドキュメントには ``DOC_MAGIC`` が設定されます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:114
 msgid ""
 "The length of this segment including the header length, fragment table, and "
 "this structure."
 msgstr ""
+"ヘッダ長、フラグメントテーブル、この構造体を含む、このセグメントの長さ。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:118
 msgid ""
 "Total length of the entire document not including meta data but including "
 "headers."
-msgstr ""
+msgstr "メタデータを含まない、ヘッダを含むドキュメント全体の長さ。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:122
 msgid ""
 "First index key in the document (the index key used to locate this object in"
 " the volume index)."
 msgstr ""
+"ドキュメントの最初のインデックスキー。（インデックスキーはボリューム"
+"インデックスにおいてこのオブジェクトを見つけるのに使用されます。)"
 
 #: ../../arch/cache/cache-data-structures.en.rst:126
 msgid ""
@@ -169,24 +197,31 @@ msgid ""
 "so that the key for the next and previous fragments can be computed from "
 "this key."
 msgstr ""
+"このフラグメントのインデックスキー。前後のフラグメントのキーがこのキーから"
+"計算出来るように、フラグメントキーは計算的に繋がっています。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:130
 msgid ""
 "Document header (metadata) length. This is not the length of the HTTP "
 "headers."
 msgstr ""
+"ドキュメントヘッダ(メタデータ)長。 HTTP ヘッダの長さではありません。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:134
 msgid ""
 "Fragment type. Currently only `CACHE_FRAG_TYPE_HTTP` is used. Other types "
 "may be used for cache extensions if those are ever used / implemented."
 msgstr ""
+"フラグメントタイプ。現在、 `CACHE_FRAG_TYPE_HTTP` のみ使用されます。キャッシュ"
+"拡張がいつか使用/実装されれば、他のタイプが使用されるかもしれません。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:138
 msgid ""
 "Fragment table length, if any. Only the first ``Doc`` in an object should "
 "contain a fragment table."
 msgstr ""
+"もしあるなら、フラグメントテーブル長。オブジェクトの、先頭の ``Doc`` のみが"
+"フラグメントテーブルを持つべきです。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:140
 msgid ""
@@ -199,30 +234,40 @@ msgid ""
 "fragment containing the first byte in the range can be computed and loaded "
 "directly without further disk access."
 msgstr ""
+"フラグメントテーブルは、 HTTP コンテンツ(メタデータや HTTP ヘッダは含みません)"
+"に関係したオフセットのリストです。各オフセットは、フラグメントの最初のバイト"
+"のバイトオフセットです。テーブルの最初の要素は、二番目のフラグメントです。"
+"(配列のインデックス 1 となるでしょう) 最初のフラグメントのオフセットはもちろん"
+"常にゼロであり、保存されません。この目的は、レンジリクエストの高速な検索を"
+"可能にすることです。先頭の ``Doc`` が指定されると、範囲の最初のバイトを"
+"含むフラグメントはそれ以上のディスクアクセス無しに、直接計算して読み込むことが"
+"できます。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:142
 msgid "Removed as of version 3.3.0."
-msgstr ""
+msgstr "バージョン 3.3.0 で削除されました。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:146
 #: ../../arch/cache/cache-data-structures.en.rst:150
 msgid "Unknown."
-msgstr ""
+msgstr "不明。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:154
 msgid "Flag and timer for pinned objects."
-msgstr ""
+msgstr "ピン留めされたオブジェクトのフラグとタイマー。"
 
 #: ../../arch/cache/cache-data-structures.en.rst:158
 msgid "Unknown. (A checksum of some sort)"
-msgstr ""
+msgstr "不明。(何らかのチェックサム)"
 
 #: ../../arch/cache/cache-data-structures.en.rst:163
 msgid "Footnotes"
-msgstr ""
+msgstr "脚注"
 
 #: ../../arch/cache/cache-data-structures.en.rst:164
 msgid ""
 "Changed in version 3.2.0. This previously resided in the first ``Doc`` but "
 "that caused different alternates to share the same fragment table."
 msgstr ""
+"バージョン 3.2.0 で変更されました。以前は先頭の ``Doc`` 内で持ちましたが、"
+"同一フラグメントテーブルを共有するために異なる代替を引き起こしました。"


### PR DESCRIPTION
`arch/cache/cache-data-structures` の翻訳を行います。
原文: https://trafficserver.readthedocs.org/en/latest/arch/cache/cache-data-structures.en.html
