### PR TITLE
DOC: Translate reference/configuration/volume.config

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/configuration/volume.config.en.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/configuration/volume.config.en.po
@@ -13,7 +13,7 @@ msgstr ""
 
 #: ../../reference/configuration/volume.config.en.rst:20
 msgid "volume.config"
-msgstr ""
+msgstr "volume.config"
 
 #: ../../reference/configuration/volume.config.en.rst:24
 msgid ""
@@ -23,6 +23,11 @@ msgid ""
 "store data from certain origin servers and/or domains in the "
 ":file:`hosting.config` file."
 msgstr ""
+":file:`volume.config` ファイルは、特定のプロトコルのために異なったサイズの"
+"キャッシュボリュームを作成することより、キャッシュスペースをより効率的に"
+"管理し、ディスクの使用を制限することを可能にします。更に、 "
+":file:`hosting.config` ファイルで定めたオリジンサーバかつ/またはドメインからの"
+"データを保存するようにボリュームを設定できます。"
 
 #: ../../reference/configuration/volume.config.en.rst:32
 msgid ""
@@ -31,16 +36,20 @@ msgid ""
 "protocol assignment. For step-by-step instructions about partitioning the "
 "cache, refer to :ref:`partitioning-the-cache`."
 msgstr ""
+"ボリューム設定はクラスターの全ノードで同一にしなければなりません。キャッシュ"
+"ボリュームサイズとプロトコル割当を変更する前に、 Traffic Server を停止しなけれ"
+"ばなりません。キャッシュのパーティショニングに関する順を追った説明については、 "
+":ref:`partitioning-the-cache` を参照してください。"
 
 #: ../../reference/configuration/volume.config.en.rst:38
 msgid "Format"
-msgstr ""
+msgstr "フォーマット"
 
 #: ../../reference/configuration/volume.config.en.rst:40
 msgid ""
 "For each volume you want to create, enter a line with the following format: "
 "::"
-msgstr ""
+msgstr "作成したいボリュームごとに、下記のフォーマットで一行追加してください。"
 
 #: ../../reference/configuration/volume.config.en.rst:45
 msgid ""
@@ -52,6 +61,13 @@ msgid ""
 "128 MB, where 128 MB is the smallest value. If you specify a percentage, "
 "then the size is rounded down to the closest multiple of 128 MB."
 msgstr ""
+"``volume_number`` は 1 から 255 （ボリュームの最大数は 255 ）の間の数であり、 "
+"``protocol_type`` は ``http`` です。 Traffic Server は HTTP ボリュームタイプと"
+"して ``http`` をサポートします。 ``volume_size`` はボリュームに割り当てられる"
+"キャッシュスペースの量です。この値はキャッシュスペースの合計のパーセンテージ"
+"もしくは絶対値が指定できます。絶対値は 128MB の倍数でなければならず、 128MB は"
+"最小値です。パーセンテージで指定する場合、サイズは最も近い 128MB の倍数に"
+"切り捨てられます。"
 
 #: ../../reference/configuration/volume.config.en.rst:54
 msgid ""
@@ -62,13 +78,20 @@ msgid ""
 "not used. You can use the extra space later to create new volumes without "
 "deleting and clearing the existing volumes."
 msgstr ""
+"各ボリュームは並列に I/O を発行するため幾つかのディスクにまたがって分散され"
+"ます。例えば、四つのディスクがある場合、 1-GB ボリュームは（各ディスクに十分な"
+"使用可能な空き領域があると仮定して）各ディスクで 256MB 持つでしょう。"
+"キャッシュの全ディスクスペースを割り当てない場合、余ったディスクスペースは使用"
+"されません。余ったスペースは後で既存ボリュームの削除やクリア無しに新しい"
+"ボリュームを作成するのに使用出来ます。"
 
 #: ../../reference/configuration/volume.config.en.rst:62
 msgid "Examples"
-msgstr ""
+msgstr "例"
 
 #: ../../reference/configuration/volume.config.en.rst:64
 msgid ""
 "The following example partitions the cache evenly between HTTP and HTTPS "
 "requests::"
 msgstr ""
+"下記の例では HTTP と HTTPS リクエストで均一にキャッシュを分割します。"


### PR DESCRIPTION
`reference/configuration/volume.config` の翻訳を行います。
原文: https://trafficserver.readthedocs.org/en/latest/reference/configuration/volume.config.en.html
