### PR TITLE
Doc: Translate glossary

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/glossary.en.po
+++ b/doc/locale/ja/LC_MESSAGES/glossary.en.po
@@ -13,24 +13,24 @@ msgstr ""
 
 #: ../../glossary.en.rst:20
 msgid "Glossary"
-msgstr ""
+msgstr "用語集"
 
 #: ../../glossary.en.rst:49
 msgid "cache span"
-msgstr ""
+msgstr "キャッシュスパン"
 
 #: ../../glossary.en.rst:51
 msgid ""
 "The physical storage described by a single line in :file:`storage.config`."
-msgstr ""
+msgstr ":file:`storage.config` の各行に記述された物理ストレージです。"
 
 #: ../../glossary.en.rst:44
 msgid "cache stripe"
-msgstr ""
+msgstr "キャッシュストライプ"
 
 #: ../../glossary.en.rst:39
 msgid "cache volume"
-msgstr ""
+msgstr "キャッシュボリューム"
 
 #: ../../glossary.en.rst:41
 msgid ""
@@ -39,6 +39,11 @@ msgid ""
 "across :term:`cache span`\\ s to increase robustness. Each section of a "
 "cache volume on a specific cache span is a :term:`cache stripe`."
 msgstr ""
+"ユーザがキャッシュとして定義した永続ストレージの単位です。キャッシュ"
+"ボリュームは :file:`volume.config` で定義されます。キャッシュボリュームは"
+"頑強性を高めるため :term:`キャッシュスパン`\\ を跨いで分散されます。特定の"
+"キャッシュスパンにおけるキャッシュボリュームの各セクションは :term:`キャッシュ"
+"ストライプ` です。"
 
 #: ../../glossary.en.rst:24
 msgid "continuation"
@@ -55,10 +60,16 @@ msgid ""
 "continue the suspended processing. This can be considered similar to co-"
 "routines."
 msgstr ""
+"状態を持った呼び出し可能なオブジェクトです。 コールバックと継続的な計算を実装"
+"するために Traffic Server で用いられるメカニズムです。外部イベントを待つ操作の"
+"ブロッキングを避けることによりトラフィックを効率良く処理するため、継続的な"
+"計算は重要です。そのような場合において、他の処理が外部イベントが起こるまで続け"
+"られるようにするため継続が使用されます。その時点で継続は中断した処理を続ける"
+"ために発動されます。これはコルーチンに似た考えができます。"
 
 #: ../../glossary.en.rst:77
 msgid "revalidation"
-msgstr ""
+msgstr "再確認"
 
 #: ../../glossary.en.rst:79
 msgid ""
@@ -67,10 +78,14 @@ msgid ""
 "rfc2616-sec14.html#sec14.25>`_ request which allows the origin server to "
 "validate the content without resending the content."
 msgstr ""
+"現在のキャッシュされたオブジェクトがまだ有効か確認することです。これは通常"
+"オリジンサーバがコンテンツの再送信をすることなくコンテンツの確認を行うことを"
+"可能にする `If-Modified-Since <http://www.w3.org/Protocols/rfc2616/rfc2616-"
+"sec14.html#sec14.25>`_ リクエストを使って行われます。"
 
 #: ../../glossary.en.rst:31
 msgid "session"
-msgstr ""
+msgstr "セッション"
 
 #: ../../glossary.en.rst:33
 msgid ""
@@ -78,18 +93,21 @@ msgid ""
 "and responses on that connection. A session starts when the client "
 "connection opens, and ends when the connection closes."
 msgstr ""
+"全てのリクエストとレスポンスをカバーする、クライアントから Traffic Server への"
+"単一のコネクションです。セッションはクライアントがコネクションをオープンした"
+"際に開始し、コネクションをクローズする際に終了します。"
 
 #: ../../glossary.en.rst:74
 msgid "storage unit"
-msgstr ""
+msgstr "ストレージユニット"
 
 #: ../../glossary.en.rst:76
 msgid "Obsolete term for :term:`cache span`."
-msgstr ""
+msgstr ":term:`キャッシュスパン` の旧称です。"
 
 #: ../../glossary.en.rst:35
 msgid "transaction"
-msgstr ""
+msgstr "トランザクション"
 
 #: ../../glossary.en.rst:37
 msgid ""
@@ -97,18 +115,21 @@ msgid ""
 "cache. A transaction begins when Traffic Server receives a request, and "
 "ends when Traffic Server sends the response."
 msgstr ""
+"クライアントのリクエストと、オリジンサーバーもしくはキャッシュからレスポンス"
+"です。トランザクションは Traffic Server がリクエストを受け付けた際に開始し、 "
+"Traffic Server がレスポンスを送る際に終了します。"
 
 #: ../../glossary.en.rst:82
 msgid "write cursor"
-msgstr ""
+msgstr "書込みカーソル"
 
 #: ../../glossary.en.rst:84
 msgid "The location in a :term:`cache stripe` where new data is written."
-msgstr ""
+msgstr "新しいデータが書き込まれる :term:`キャッシュストライプ` の位置です。"
 
 #: ../../glossary.en.rst:68
 msgid "alternate"
-msgstr ""
+msgstr "代替"
 
 #: ../../glossary.en.rst:70
 msgid ""
@@ -119,10 +140,15 @@ msgid ""
 "alternate forms of the same stream. The most common example is having "
 "normal and compressed versions of the stream."
 msgstr ""
+":term:`キャッシュオブジェクト` の変形です。元々は `VARY メカニズム <http://"
+"www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44>`_ を処理するために"
+"作られましたが、以来他の目的のためにも使われています。オブジェクトの全ての"
+"代替は何らかの方法で同質にならなければならず、同じストリームの形式に変化"
+"します。最も一般的な例はストリームの通常版と圧縮版を持つことです。"
 
 #: ../../glossary.en.rst:97
 msgid "cache fragment"
-msgstr ""
+msgstr "キャッシュフラグメント"
 
 #: ../../glossary.en.rst:99
 msgid ""
@@ -132,10 +158,15 @@ msgid ""
 "corresponding :term:`directory entry` which describes its location in the "
 "cache storage."
 msgstr ""
+"キャッシュ内のストレージの単位です。キャッシュの全ての読込みは常にちょうど"
+"一つのフラグメントを読み込みます。フラグメントはまとめて書き込まれるかも知れま"
+"せんが、全ての書込みは常にフラグメントの整数になります。各フラグメントは "
+"キャッシュストレージにおける自身の位置情報を持つ :term:`ディレクトリエントリ` "
+"に対応しています。"
 
 #: ../../glossary.en.rst:56
 msgid "cache ID"
-msgstr ""
+msgstr "キャッシュ ID"
 
 #: ../../glossary.en.rst:58
 msgid ""
@@ -143,20 +174,25 @@ msgid ""
 "cache. This is computed from the :term:`cache key` using the `MD5 hashing "
 "function <http://www.openssl.org/docs/crypto/md5.html>`_."
 msgstr ""
+"キャッシュのオブジェクトの固定サイズの識別子として使用される 128 ビットの値"
+"です。 `MD5 ハッシュ関数 <http://www.openssl.org/docs/crypto/md5.html>`_ を"
+"用いて :term:`キャッシュキー` から計算されます。"
 
 #: ../../glossary.en.rst:52
 msgid "cache key"
-msgstr ""
+msgstr "キャッシュキー"
 
 #: ../../glossary.en.rst:54
 msgid ""
 "A byte sequence that is a globally unique identifier for an :term:`object "
 "<cache object>` in the cache. By default the URL for the object is used."
 msgstr ""
+"キャッシュの :term:`オブジェクト <キャッシュオブジェクト>` の大域的にユニーク"
+"な識別子のバイト列です。デフォルトではオブジェクトの URL が使用されます。"
 
 #: ../../glossary.en.rst:64
 msgid "cache object"
-msgstr ""
+msgstr "キャッシュオブジェクト"
 
 #: ../../glossary.en.rst:66
 msgid ""
@@ -165,6 +201,9 @@ msgid ""
 "single object can have multiple variants called :term:`alternates "
 "<alternate>`."
 msgstr ""
+"キャッシュのデータの最小の自己完結した単位です。キャッシュオブジェクトは"
+"オリジンサーバーからのコンテンツストリームと等価な保存されたバージョンです。"
+"単一のオブジェクトは :term:`代替 <代替>` と呼ばれる複数の変形を持ち得ます。"
 
 #: ../../glossary.en.rst:46
 msgid ""
@@ -173,10 +212,13 @@ msgid ""
 "as an undifferentiated span of bytes. This is the smallest independent unit "
 "of storage."
 msgstr ""
+"単一の :term:`キャッシュスパン` におけるキャッシュの同質な永続ストアです。"
+"ストライプは常に一つの物理デバイスに全体的に置かれ、区別されないバイト列の"
+"スパンとして扱われます。これはストレージの最小の独立した単位です。"
 
 #: ../../glossary.en.rst:60
 msgid "cache tag"
-msgstr ""
+msgstr "キャッシュタグ"
 
 #: ../../glossary.en.rst:62
 msgid ""
@@ -184,28 +226,33 @@ msgid ""
 "the :ref:`cache directory <cache-directory>` for a preliminary identity "
 "check before going to disk."
 msgstr ""
+":term:`キャッシュ ID` の下位数ビット（現在は 12）です。ディスクへアクセスする"
+"前に予備的な識別チェックを行うために :ref:`キャッシュディレクトリ <cache-"
+"directory>` で使用されます。"
 
 #: ../../glossary.en.rst:90
 msgid "directory bucket"
-msgstr ""
+msgstr "ディレクトリバケット"
 
 #: ../../glossary.en.rst:92
 msgid ""
 "A contiguous fixed sized group of :term:`directory entries <directory "
 "entry>`. This is used for hash bucket maintenance optimization."
 msgstr ""
+"隣接した :term:`ディレクトリエントリ <ディレクトリエントリ>` の固定サイズの"
+"グループです。ハッシュバケットのメンテナンスの最適化に使用されます。"
 
 #: ../../glossary.en.rst:94
 msgid "directory entry"
-msgstr ""
+msgstr "ディレクトリエントリ"
 
 #: ../../glossary.en.rst:96
 msgid "An in memory entry that describes a :term:`cache fragment`."
-msgstr ""
+msgstr ":term:`キャッシュフラグメント` を指すメモリに置かれるエントリです。"
 
 #: ../../glossary.en.rst:85
 msgid "directory segment"
-msgstr ""
+msgstr "ディレクトリセグメント"
 
 #: ../../glossary.en.rst:87
 msgid ""
@@ -215,3 +262,8 @@ msgid ""
 "Segments are administrative in purpose to minimize the size of free list "
 "and hash bucket pointers."
 msgstr ""
+"隣接した :term:`バケット <ディレクトリバケット>` のグループです。"
+"セグメントあたりのバケット数はキャッシュストライプの間で変化する可能性があり"
+"ますが、各 :term:`キャッシュストライプ` は同じ数のバケットを持つ全ての"
+"セグメントのセットを持ちます。セグメントはフリーリストとハッシュバケット"
+"ポインタのサイズを最小限にするため管理できます。"


### PR DESCRIPTION
`glossary.en.rst` の翻訳です。
原文: https://trafficserver.readthedocs.org/en/latest/glossary.en.html
